### PR TITLE
Add function for quickly searching the last message of a user in an introductions channel

### DIFF
--- a/Resources.json
+++ b/Resources.json
@@ -5,5 +5,10 @@
     "logCh" : 611375108056940555,
     "welcome" : "Welcome {0} to the Nijigasaki High School Idol Club! Please read the {1} and feel free to introduce yourself!",
     "nijiCord" : 610931193516392472,
-    "ModBotCH" : 611472744302772234
+    "ModBotCH" : 611472744302772234,
+    "introChannel": {
+        "834831787959910410": {
+            "channel": 836281441196572722
+        }
+    }
 }

--- a/cogs/guildFunctions.py
+++ b/cogs/guildFunctions.py
@@ -439,6 +439,8 @@ class GuildFunctions(commands.Cog):
 					msg_suppressed = utils.suppress_links(msg.content)
 					await ctx.send(msg_suppressed)
 					return
+			await ctx.send("Message not found! Maybe the user hasn't posted an introduction yet?")
+			return
 
 
 	@ commands.command()

--- a/cogs/guildFunctions.py
+++ b/cogs/guildFunctions.py
@@ -436,7 +436,8 @@ class GuildFunctions(commands.Cog):
 		async with ctx.typing():
 			async for msg in _ch.history(limit=10000):
 				if msg.author == user:
-					await ctx.send(msg.content)
+					msg_suppressed = utils.suppress_links(msg.content)
+					await ctx.send(msg_suppressed)
 					return
 
 

--- a/cogs/guildFunctions.py
+++ b/cogs/guildFunctions.py
@@ -392,6 +392,51 @@ class GuildFunctions(commands.Cog):
 			return
 		await self.setRole(ctx, roleNames, role)
 
+
+	@ commands.command()
+	async def whois(self, ctx, *, user: Union[discord.User, str] = None):
+		"""Want to quickly find out who a user is? Just type '$whois name_of_user' to find their introduction message!"""
+		if user is None:
+			await ctx.send("Please provide the name of the user of interest")
+			return
+
+		_guild = ctx.message.guild.id
+		if not (
+			("introChannel" in self.bot.config)
+			and (_guild in self.bot.config["introChannel"])
+		):
+			await ctx.send("Error! Introductions channel not found :(")
+			return
+
+		# Find a user by name (if a string is passed)
+		if not isinstance(user, discord.User):
+			_user_matches = list(filter(
+				lambda u: (
+					(user.lower() in u.name.lower())
+					or (user.lower() in u.display_name.lower())
+				),
+				ctx.message.guild.members
+			))
+
+			# If more than 1 match found, pls clarify
+			if len(_user_matches) > 1:
+				output_msg = "Please be more specific! Did you mean:\n"
+				for _u in _user_matches:
+					output_msg += "\t{} ({})\n".format(_u.display_name, _u.name)
+				await ctx.send(output_msg)
+			elif len(_user_matches) == 0:
+				await ctx.send("User not found")
+			else:
+				user = _user_matches[0]
+
+		_chid = self.bot.config["introChannel"][_guild]["channel"]
+		_ch = self.bot.get_channel(_chid)
+		async for msg in _ch.history(limit=10000):
+			if msg.author == user:
+				await ctx.send(msg.content)
+				return
+
+
 	@ commands.command()
 	@ checks.is_niji()
 	async def sub(self, ctx, *, role):

--- a/cogs/guildFunctions.py
+++ b/cogs/guildFunctions.py
@@ -424,17 +424,20 @@ class GuildFunctions(commands.Cog):
 				for _u in _user_matches:
 					output_msg += "\t{} ({})\n".format(_u.display_name, _u.name)
 				await ctx.send(output_msg)
+				return
 			elif len(_user_matches) == 0:
 				await ctx.send("User not found")
+				return
 			else:
 				user = _user_matches[0]
 
 		_chid = self.bot.config["introChannel"][_guild]["channel"]
 		_ch = self.bot.get_channel(_chid)
-		async for msg in _ch.history(limit=10000):
-			if msg.author == user:
-				await ctx.send(msg.content)
-				return
+		async with ctx.typing():
+			async for msg in _ch.history(limit=10000):
+				if msg.author == user:
+					await ctx.send(msg.content)
+					return
 
 
 	@ commands.command()

--- a/cogs/utilities/utils.py
+++ b/cogs/utilities/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import random
 import time
+import re
 
 import discord
 import pytz
@@ -117,3 +118,7 @@ def getInstaEmbed(token, url):
 		embd.timestamp = timestamp[1] 
 	return embd
 
+def suppress_links(msg):
+	"""Given a message, will find links using regex and surround them with <>"""
+	linkRegex = re.compile(r'((http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/\S*)?)+')
+	return re.sub(linkRegex, r'<\1>', msg)


### PR DESCRIPTION
PR includes changes in the `Resources.json` that correspond to the LLCC server and introductions channel (and how it'd be structured in the Yaml file)

Introductions channel:

![testcase-3](https://user-images.githubusercontent.com/84141734/118355067-b15d2b00-b5a0-11eb-894d-4b0b47bf2204.PNG)

General channel (using the feature):

![testcase-1](https://user-images.githubusercontent.com/84141734/118355083-c76aeb80-b5a0-11eb-9fad-f7374f63b5b7.PNG)

![testcase-2](https://user-images.githubusercontent.com/84141734/118355087-cb970900-b5a0-11eb-8c18-7822ec92e9bc.PNG)

![testcase-4](https://user-images.githubusercontent.com/84141734/118355089-cdf96300-b5a0-11eb-9341-5a1ed804384b.PNG)

Current questions:

* Will the simple for-loop be fine for the use case (or if there should be a better way to go about it)
* Will a simple substring search be fine (or if I should do something more specific like prioritizing display name or using fuzzy search)
* Will I have to suppress link previews